### PR TITLE
コンテナ停止時に EpgTimerSrv を正規の方法で終了する

### DIFF
--- a/edcb/Dockerfile
+++ b/edcb/Dockerfile
@@ -49,9 +49,6 @@ ENV MIRKAC_ADDRESS=
 ENV MIRAKC_PORT=
 ENV UMASK=
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
 # copy EDCB_Material_WebUI
 # (setup on entrypoint.sh)
 COPY --from=build /app/EDCB_Material_WebUI /usr/local/src/EDCB_Material_WebUI
@@ -108,6 +105,9 @@ RUN ln -s /usr/local/lib/edcb/BonDriver_LinuxMirakc.so /usr/local/lib/edcb/BonDr
   ln -s /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini /usr/local/lib/edcb/BonDriver_LinuxMirakc.so.ini && \
   ln -s /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini /usr/local/lib/edcb/BonDriver_LinuxMirakc_S.so.ini && \
   ln -s /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini /usr/local/lib/edcb/BonDriver_LinuxMirakc_T.so.ini
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 4510 5510
 ENTRYPOINT ["/entrypoint.sh"]

--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -14,10 +14,23 @@ if [ -n "$UMASK" ]; then
 fi
 
 # first run or updated: copy EDCB_Material_WebUI to volume
-cp -rn /usr/local/src/EDCB_Material_WebUI/Setting /var/local/edcb/
-cp -ru /usr/local/src/EDCB_Material_WebUI/HttpPublic /var/local/edcb/
+cp -rn /usr/local/s3-exit-on-container-stoprc/EDCB_Material_WebUI/HttpPublic /var/local/edcb/
 
 # first run or updated: setup EDCB ini files
 (cd /usr/local/src/EDCB/Document/Unix && make -s setup_ini)
 
-EpgTimerSrv
+terminate_edcb() {
+  # terminal EpgTimerSrv and all child processes such as EpgDataCap_Bon
+  kill -TERM -$PGID
+  pidwait -g $PGID > /dev/null 2>&1
+}
+
+# see: https://docs.docker.jp/engine/reference/builder.html#exec-entrypoint
+trap terminate_edcb HUP INT QUIT TERM
+
+setsid EpgTimerSrv &
+SRV_PID=$!
+PGID=$(ps -o pgid= -p $SRV_PID | tr -d ' ')
+
+# wait for terminate_edcb() or unexpected exit EpgTimerSrv
+wait $SRV_PID


### PR DESCRIPTION
### 対応内容

* `docker compose stop` などによるコンテナ停止時
  * EpgTImerSrv に SIGTERM を送信する
  * EPG 取得・録画のため EpgTImerSrv が起動した EpgDataCarp_Bon などの子プロセスにも SIGTERM を送信する
* `entrypoint.sh` 改変時のビルドを高速化するため、Dockerfile での COPY 等を行う位置を変更

### 条件

7460ba8 コミットの EDCB を使用
https://github.com/tkntrec/EDCB/tree/7460ba889fda231055230e4dbfe4c349086d98d2

### 備考

EpgTImerSrv のみに SIGTERM を渡したい場合は `Dockerfile` を

```
exec EpgTimerSrv
```

に書き換えるだけで十分だった。  
ただし EPG 取得・録画用に立ち上げられた EpgDataCarp_Bon プロセスは生き続けるため、これらにも SIGTERM を送り待機するようにした。

Closes #3 