### PR TITLE
mirakc 関連の環境変数のスペルミス

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ EDCB の設定ファイルには介入しないため、セットアップに手
 ### 外部の mirakc・Mirakurun を使用する場合
 
 `compose.yml` を改変し EDCB のみを実行する場合など。  
-edcb コンテナの環境変数 `MIRKAC_ADDRESS` で mirakc または Mirakurun のアドレスを指定できます。
+edcb コンテナの環境変数 `MIRAKC_ADDRESS` で mirakc または Mirakurun のアドレスを指定できます。
 
 IP アドレスで指定する場合は、特に問題ありません。
 

--- a/compose-sample.yml
+++ b/compose-sample.yml
@@ -49,8 +49,8 @@ services:
     #   - video
     environment:
       - TZ=Asia/Tokyo
-      - MIRKAC_ADDRESS=mirakc
-      - MIRKAC_PORT=40772
+      - MIRAKC_ADDRESS=mirakc
+      - MIRAKC_PORT=40772
       # - UMASK=002
 
 volumes:

--- a/edcb/Dockerfile
+++ b/edcb/Dockerfile
@@ -45,7 +45,7 @@ RUN git clone https://github.com/tkntrec/EDCB.git && \
 
 FROM ${ARCH}ubuntu:24.04
 
-ENV MIRKAC_ADDRESS=
+ENV MIRAKC_ADDRESS=
 ENV MIRAKC_PORT=
 ENV UMASK=
 

--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # write mirakc server settings to BonDriver_LinuxMirakc.so.ini
 # due to BonDriver_LinuxMirakc can not resolve host name currently
-MIRAKC_IP_ADDRESS=$(getent hosts $MIRKAC_ADDRESS | awk '{ print $1 }')
+MIRAKC_IP_ADDRESS=$(getent hosts $MIRAKC_ADDRESS | awk '{ print $1 }')
 sed -i "s/^SERVER_HOST=.*/SERVER_HOST=\"$MIRAKC_IP_ADDRESS\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 sed -i "s/^SERVER_PORT=.*/SERVER_PORT=\"$MIRAKC_PORT\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 


### PR DESCRIPTION
Closes #6 

`MIRKAC_ADDRESS` や `MIRKAC_PORT` の typo 修正。

`compose.yml` ( `compose-sample.yml` ) の定義にも影響するため、ユーザへの周知が必要。
この typo のため `MIRKAC_PORT` (修正後: `MIRAKC_PORT` ) は指定しても作用しない状態だった。