### PR TITLE
MIRAKC_ADDRESS への IP アドレス指定時に名前解決させない

### DIFF
--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -3,6 +3,15 @@
 # write mirakc server settings to BonDriver_LinuxMirakc.so.ini
 # due to BonDriver_LinuxMirakc can not resolve host name currently
 MIRAKC_IP_ADDRESS=$(getent ahosts $MIRAKC_ADDRESS | sed -n 's/ *STREAM.*//p' | head -n 1)
+if [ -z "$MIRAKC_IP_ADDRESS" ]; then
+  echo "ERROR: Could not resolve IP address for mirakc server."
+  exit 1
+fi
+if [ -z "$MIRAKC_PORT" ]; then
+  echo "ERROR: MIRAKC_PORT is not set."
+  exit 1
+fi
+
 sed -i "s/^SERVER_HOST=.*/SERVER_HOST=\"$MIRAKC_IP_ADDRESS\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 sed -i "s/^SERVER_PORT=.*/SERVER_PORT=\"$MIRAKC_PORT\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 

--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # write mirakc server settings to BonDriver_LinuxMirakc.so.ini
 # due to BonDriver_LinuxMirakc can not resolve host name currently
-MIRAKC_IP_ADDRESS=$(getent hosts $MIRAKC_ADDRESS | awk '{ print $1 }')
+MIRAKC_IP_ADDRESS=$(getent ahosts $MIRAKC_ADDRESS | sed -n 's/ *STREAM.*//p' | head -n 1)
 sed -i "s/^SERVER_HOST=.*/SERVER_HOST=\"$MIRAKC_IP_ADDRESS\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 sed -i "s/^SERVER_PORT=.*/SERVER_PORT=\"$MIRAKC_PORT\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 


### PR DESCRIPTION
Closes #8 

`getent hosts` の代わりに `getent ahosts` を使用することによって、自身の物理 NIC や `192.168.0.0/24` 内ななどのアドレスの指定でそのまま出力されるようにした。
名前解決できない場合などのバリデーションも追加した。