### PR TITLE
mirakc 関連の環境変数のスペルミス - 後方互換性をもたせる

### DIFF
--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# === BonDriver_LinuxMirakc setup ===
+# === setup BonDriver_LinuxMirakc ===
 
 # write mirakc server settings to BonDriver_LinuxMirakc.so.ini
 # due to BonDriver_LinuxMirakc can not resolve host name currently
@@ -22,7 +22,8 @@ fi
 sed -i "s/^SERVER_HOST=.*/SERVER_HOST=\"$MIRAKC_IP_ADDRESS\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 sed -i "s/^SERVER_PORT=.*/SERVER_PORT=\"$MIRAKC_PORT\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 
-# === end of BonDriver_LinuxMirakc setup ===
+# === end of setup BonDriver_LinuxMirakc ===
+
 
 # clean old *.fifo files made by SrvPipe from the previous run
 rm -f /var/local/edcb/*.fifo

--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
+# === BonDriver_LinuxMirakc setup ===
+
 # write mirakc server settings to BonDriver_LinuxMirakc.so.ini
 # due to BonDriver_LinuxMirakc can not resolve host name currently
+
+# typo collection for under v1.0.4 compose.yml
+if [ -z "$MIRAKC_ADDRESS" ] && [ -n "$MIRKAC_ADDRESS" ]; then MIRAKC_ADDRESS=$MIRKAC_ADDRESS; fi
+if [ -z "$MIRAKC_PORT" ] && [ -n "$MIRKAC_PORT" ]; then MIRAKC_PORT=$MIRKAC_PORT; fi
+
 MIRAKC_IP_ADDRESS=$(getent ahosts $MIRAKC_ADDRESS | sed -n 's/ *STREAM.*//p' | head -n 1)
 if [ -z "$MIRAKC_IP_ADDRESS" ]; then
   echo "ERROR: Could not resolve IP address for mirakc server."
@@ -15,12 +22,12 @@ fi
 sed -i "s/^SERVER_HOST=.*/SERVER_HOST=\"$MIRAKC_IP_ADDRESS\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 sed -i "s/^SERVER_PORT=.*/SERVER_PORT=\"$MIRAKC_PORT\"/" /var/local/BonDriver_LinuxMirakc/BonDriver_LinuxMirakc.so.ini
 
+# === end of BonDriver_LinuxMirakc setup ===
+
 # clean old *.fifo files made by SrvPipe from the previous run
 rm -f /var/local/edcb/*.fifo
 
-if [ -n "$UMASK" ]; then
-  umask $UMASK
-fi
+if [ -n "$UMASK" ]; then umask $UMASK; fi
 
 # first run or updated: copy EDCB_Material_WebUI to volume
 cp -rn /usr/local/src/EDCB_Material_WebUI/Setting /var/local/edcb/

--- a/edcb/entrypoint.sh
+++ b/edcb/entrypoint.sh
@@ -5,7 +5,7 @@
 # write mirakc server settings to BonDriver_LinuxMirakc.so.ini
 # due to BonDriver_LinuxMirakc can not resolve host name currently
 
-# typo collection for under v1.0.4 compose.yml
+# typo correction for under v1.0.4 compose.yml
 if [ -z "$MIRAKC_ADDRESS" ] && [ -n "$MIRKAC_ADDRESS" ]; then MIRAKC_ADDRESS=$MIRKAC_ADDRESS; fi
 if [ -z "$MIRAKC_PORT" ] && [ -n "$MIRKAC_PORT" ]; then MIRAKC_PORT=$MIRKAC_PORT; fi
 


### PR DESCRIPTION
Closes #6 

typo を含む `MIRKAC_ADDRESS` および `MIRKAC_PORT` 環境変数を指定したとき、読み替えるようにした。